### PR TITLE
Enhance workflow and leaderboard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: 📦 Install dependencies
         run: npm install
 
+      - name: 🧪 Run tests
+        run: npm test
+
       - name: Deploy slash commands
         run: node deploy-commands.js
         

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # VibeBit-test
+
+## Running tests
+
+```
+npm test
+```
+
+This runs a simple check ensuring command files exist.

--- a/commands/leaderboard.js
+++ b/commands/leaderboard.js
@@ -2,10 +2,22 @@ const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('ping')
-    .setDescription('Replies with Pong!'),
+    .setName('leaderboard')
+    .setDescription('Show top trivia players'),
   async execute(interaction) {
-    await interaction.deferReply({ flags: 1 << 6 }); // Ephemeral using flags
-    await interaction.editReply('🏓 Pong!');
+    await interaction.deferReply({ flags: 1 << 6 });
+
+    const data = require('../leaderboard.json');
+    const sorted = Object.entries(data)
+      .sort(([, a], [, b]) => b.score - a.score)
+      .slice(0, 10);
+
+    if (sorted.length === 0) {
+      await interaction.editReply('📭 No leaderboard data.');
+      return;
+    }
+
+    const lines = sorted.map(([id, info], i) => `**${i + 1}.** <@${id}> — ${info.score}`);
+    await interaction.editReply(lines.join('\n'));
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "commonjs",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "keywords": [],
   "author": "",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+const commandsDir = path.join(__dirname, 'commands');
+const files = fs.readdirSync(commandsDir).filter(f => f.endsWith('.js'));
+if (files.length === 0) {
+  console.error('No command files found');
+  process.exit(1);
+}
+console.log(`Found ${files.length} command files.`);


### PR DESCRIPTION
## Summary
- add simple Node test
- fix `/leaderboard` command to show scores
- run tests in workflow
- document tests in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aaaf11d20833387e17337bd6f0938