### PR TITLE
Fix trailing whitespace in db module

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -38,4 +38,4 @@ module.exports = {
   decode,
   shuffle,
   updateLeaderboard
-}; 
+};


### PR DESCRIPTION
## Summary
- clean up a stray non-breaking space and ensure db.js ends with a newline

## Testing
- `node -c lib/db.js`

------
https://chatgpt.com/codex/tasks/task_e_688aaeab8c9c8333873cefa3a156422e